### PR TITLE
Extension engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ GeoLite2*.gz
 *.tar.xz
 whitelist
 dns_servers
+extensions/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Usage of ./geoip-service:
         The list of DNS servers. If not specified defaults to Cloudflare, Google, and OpenDNS
   -domain string
         A domain name
+  -ext-dir string
+        Specify the location of the folder containing the extensions
   -ip string
         An IP address
   -pub-dir string
@@ -47,3 +49,68 @@ Usage of ./geoip-service:
 ```
 
 The `-pub-dir` flag can be used to specify a front end application that calls all the APIs. There's an example of this in the [geoip-service-fe](https://github.com/wisepythagoras/geoip-service-fe) repository.
+
+### Extensions
+
+The app has an integrated extension engine which is mostly meant to be used when running it as an API server. An extension can register API endpoints, run cron jobs, and manage data on their own, which the main app can query. Below you'll find an example of an extension that queries data from a 3rd party IP list.
+
+``` js
+const IP_LIST_DATA = 'https://some.org/some_ip_list.ipset';
+const DATA_FILE = 'data.json';
+const ipList = [];
+
+const listHasIP = (ip) => {
+    for (let i = 0; i < ipList.length; i++) {
+        if (ipList[i].contains(ip)) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+const lookupIP = (ip) => {
+    if (listHasIP(ip)) {
+        // This data will appear as `additional_info` in the API response.
+        return {
+            info: 'This IP was marked as XXXX',
+            list: IP_LIST_DATA,
+            tag: 'XXXX',
+        };
+    }
+};
+
+const refreshData = () => {
+    // Run `fetch` to get the data and then `storage.save` to save the updated version.
+};
+
+// If you define `hasLookup` in the config then you need a function with this name.
+const loadData = async () => {
+    await storage.init();
+
+    try {
+        const json = await storage.read(DATA_FILE);
+        const data = JSON.parse(json);
+
+        data.forEach((ip) => {
+            ipList.push(new IP(ip));
+        });
+    } catch (e) {
+        console.log('Error:', e);
+    }
+};
+
+const install = () => {
+    loadData();
+
+    return {
+        version: 1,
+        hasLookup: true,
+        jobs: [{
+            // A cron that runs every hour.
+            cron: '0 * * * *',
+            job: 'refreshData',
+        }],
+    };
+};
+```

--- a/extension.go
+++ b/extension.go
@@ -75,8 +75,8 @@ func (e *Extension) Init() error {
 	fetchFn := jsapi.Fetch{VM: e.vm}
 	fetchFn.Create()
 
-	jsIPObj := jsapi.JSIP{VM: e.vm}
-	jsIPObj.Init()
+	ipListObj := jsapi.IPList{VM: e.vm}
+	ipListObj.Init()
 
 	_, err = e.vm.RunScript(e.dir.Name(), string(bytes))
 

--- a/extension.go
+++ b/extension.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -140,51 +139,4 @@ func (e *Extension) registerEndpoint(r *gin.Engine, details EndpointDetails) boo
 	}
 
 	return true
-}
-
-func parseExtensions(path string) ([]*Extension, error) {
-	files, err := os.ReadDir(path)
-	extensions := []*Extension{}
-
-	if err != nil {
-		return extensions, err
-	}
-
-	for _, f := range files {
-		if !f.IsDir() {
-			break
-		}
-
-		extFiles, err := os.ReadDir(filepath.Join(path, f.Name()))
-
-		if err != nil {
-			return extensions, err
-		}
-
-		var entry os.DirEntry = nil
-
-		for _, extFile := range extFiles {
-			if extFile.IsDir() {
-				continue
-			}
-
-			if extFile.Name() == "index.js" {
-				entry = extFile
-			}
-		}
-
-		if entry == nil {
-			return extensions, fmt.Errorf("Extension folder %q doesn't have an entry point (index.js)", f.Name())
-		}
-
-		extension := &Extension{
-			extDir: path,
-			dir:    f,
-			entry:  entry,
-		}
-
-		extensions = append(extensions, extension)
-	}
-
-	return extensions, nil
 }

--- a/extension.go
+++ b/extension.go
@@ -36,6 +36,7 @@ type CronJob struct {
 
 type ExtensionConfig struct {
 	Version   int               `json:"version"`
+	HasLookup bool              `json:"hasLookup"`
 	Endpoints []EndpointDetails `json:"endpoints"`
 	Jobs      []CronJob         `json:"jobs"`
 }
@@ -49,6 +50,7 @@ type Extension struct {
 	entry     os.DirEntry
 	vm        *js.Runtime
 	endpoints []EndpointDetails
+	hasLookup bool
 	scheduler *gocron.Scheduler
 }
 
@@ -101,6 +103,7 @@ func (e *Extension) Init() error {
 
 	res := installFn()
 	e.endpoints = res.Endpoints
+	e.hasLookup = res.HasLookup
 
 	e.scheduler = gocron.NewScheduler(time.UTC)
 
@@ -124,6 +127,12 @@ func (e *Extension) Init() error {
 // IsEndpointExtension returns true if this extension defines an endpoint.
 func (e *Extension) IsEndpointExtension() bool {
 	return len(e.endpoints) > 0
+}
+
+// IsLookupExtension returns true if this extension has lookup functions and should run
+// on IP or domain lookup.
+func (e *Extension) IsLookupExtension() bool {
+	return e.hasLookup
 }
 
 // RegisterEndpoints will go through all of the endpoints and register them with gin.

--- a/extension.go
+++ b/extension.go
@@ -81,6 +81,12 @@ func (e *Extension) Init() error {
 	ipObj := jsapi.JSIP{VM: e.vm}
 	ipObj.Init()
 
+	storageObj := jsapi.Storage{
+		VM:      e.vm,
+		DataDir: filepath.Join(e.extDir, e.dir.Name(), ".store"),
+	}
+	storageObj.Init()
+
 	_, err = e.vm.RunScript(e.dir.Name(), string(bytes))
 
 	if err != nil {

--- a/extension.go
+++ b/extension.go
@@ -67,11 +67,16 @@ func (e *Extension) Init() error {
 		return err
 	}
 
+	// Add all the APIs to the VM's runtime.
+
 	consoleObj := jsapi.Console{VM: e.vm}
 	consoleObj.Create()
 
 	fetchFn := jsapi.Fetch{VM: e.vm}
 	fetchFn.Create()
+
+	jsIPObj := jsapi.JSIP{VM: e.vm}
+	jsIPObj.Init()
 
 	_, err = e.vm.RunScript(e.dir.Name(), string(bytes))
 

--- a/extension.go
+++ b/extension.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -134,7 +133,6 @@ func (e *Extension) registerEndpoint(r *gin.Engine, details EndpointDetails) boo
 				wg.Done()
 			},
 			Abort: func(status int, err string) {
-				fmt.Println("Aborting", status)
 				c.AbortWithError(status, errors.New(err))
 				wg.Done()
 			},

--- a/extension.go
+++ b/extension.go
@@ -78,6 +78,9 @@ func (e *Extension) Init() error {
 	ipListObj := jsapi.IPList{VM: e.vm}
 	ipListObj.Init()
 
+	ipObj := jsapi.JSIP{VM: e.vm}
+	ipObj.Init()
+
 	_, err = e.vm.RunScript(e.dir.Name(), string(bytes))
 
 	if err != nil {

--- a/extension.go
+++ b/extension.go
@@ -9,7 +9,7 @@ import (
 	js "github.com/dop251/goja"
 	"github.com/gin-gonic/gin"
 	"github.com/mitchellh/mapstructure"
-	jsapi "github.com/wisepythagoras/geoip-service/js_api"
+	"github.com/wisepythagoras/geoip-service/jsapi"
 )
 
 type EndpointReq struct {

--- a/extension.go
+++ b/extension.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	js "github.com/dop251/goja"
+	"github.com/gin-gonic/gin"
+	"github.com/mitchellh/mapstructure"
+)
+
+type EndpointReq struct {
+	Param func(key string) string `json:"param"`
+}
+
+type EndpointRes struct {
+	Send func(status int, resp ApiResponse) `json:"send"`
+}
+
+type EndpointDetails struct {
+	Endpoint string `json:"endpoint"`
+	Method   string `json:"method"`
+	Handler  string `json:"handler"`
+}
+
+type ExtensionConfig struct {
+	Type    string `json:"type"`
+	Version int    `json:"version"`
+	Details any    `json:"details"`
+}
+
+type InstallFn func() ExtensionConfig
+type HandlerFn func(req EndpointReq, res EndpointRes)
+
+type Extension struct {
+	extDir        string
+	dir           os.DirEntry
+	entry         os.DirEntry
+	vm            *js.Runtime
+	extType       string
+	configDetails any
+}
+
+// Init will spin up the JS VM and run the script.
+func (e *Extension) Init() error {
+	e.vm = js.New()
+	e.vm.SetFieldNameMapper(js.TagFieldNameMapper("json", true))
+
+	entryPath := filepath.Join(e.extDir, e.dir.Name(), e.entry.Name())
+	bytes, err := os.ReadFile(entryPath)
+
+	if err != nil {
+		return err
+	}
+
+	e.vm.Set("log", func(call js.FunctionCall) js.Value {
+		for _, arg := range call.Arguments {
+			fmt.Print(arg.String())
+		}
+
+		fmt.Println()
+
+		return js.Undefined()
+	})
+
+	_, err = e.vm.RunScript(e.dir.Name(), string(bytes))
+
+	if err != nil {
+		return err
+	}
+
+	// The first step is to find and call the `install` function. This is a required part of
+	// any extension and returns the extension's configuration.
+	var installFn InstallFn
+	err = e.vm.ExportTo(e.vm.Get("install"), &installFn)
+
+	if err != nil {
+		return err
+	}
+
+	res := installFn()
+	e.extType = res.Type
+	e.configDetails = res.Details
+
+	return nil
+}
+
+// IsEndpointExtension returns true if this extension defines an endpoint.
+func (e *Extension) IsEndpointExtension() bool {
+	if len(e.extType) == 0 {
+		return false
+	}
+
+	return e.extType == "endpoint"
+}
+
+// RegisterEndpoints will go through all of the endpoints and register them with gin.
+func (e *Extension) RegisterEndpoints(r *gin.Engine) bool {
+	if !e.IsEndpointExtension() {
+		return false
+	}
+
+	var details []EndpointDetails
+	mapstructure.Decode(e.configDetails, &details)
+
+	for _, d := range details {
+		if !e.registerEndpoint(r, d) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (e *Extension) registerEndpoint(r *gin.Engine, details EndpointDetails) bool {
+	var handler HandlerFn
+	err = e.vm.ExportTo(e.vm.Get(details.Handler), &handler)
+
+	endpoint := filepath.Join("/api", details.Endpoint)
+
+	endpointHandler := func(c *gin.Context) {
+		req := EndpointReq{
+			Param: c.Param,
+		}
+		res := EndpointRes{
+			Send: func(status int, resp ApiResponse) {
+				c.JSON(status, resp)
+			},
+		}
+
+		handler(req, res)
+	}
+
+	if details.Method == "GET" {
+		r.GET(endpoint, endpointHandler)
+	} else if details.Method == "POST" {
+		r.POST(endpoint, endpointHandler)
+	} else if details.Method == "PUT" {
+		r.PUT(endpoint, endpointHandler)
+	} else if details.Method == "DELETE" {
+		r.DELETE(endpoint, endpointHandler)
+	}
+
+	return true
+}
+
+func parseExtensions(path string) ([]*Extension, error) {
+	files, err := os.ReadDir(path)
+	extensions := []*Extension{}
+
+	if err != nil {
+		return extensions, err
+	}
+
+	for _, f := range files {
+		if !f.IsDir() {
+			break
+		}
+
+		extFiles, err := os.ReadDir(filepath.Join(path, f.Name()))
+
+		if err != nil {
+			return extensions, err
+		}
+
+		var entry os.DirEntry = nil
+
+		for _, extFile := range extFiles {
+			if extFile.IsDir() {
+				continue
+			}
+
+			if extFile.Name() == "index.js" {
+				entry = extFile
+			}
+		}
+
+		if entry == nil {
+			return extensions, fmt.Errorf("Extension folder %q doesn't have an entry point (index.js)", f.Name())
+		}
+
+		extension := &Extension{
+			extDir: path,
+			dir:    f,
+			entry:  entry,
+		}
+
+		extensions = append(extensions, extension)
+	}
+
+	return extensions, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dop251/goja v0.0.0-20221229151140-b95230a9dbad // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-contrib/static v0.0.1 // indirect
+	github.com/go-co-op/gocron v1.18.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.11.1 // indirect
@@ -25,9 +26,11 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/net v0.4.0 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,15 +9,19 @@ require (
 )
 
 require (
+	github.com/dlclark/regexp2 v1.7.0 // indirect
+	github.com/dop251/goja v0.0.0-20221229151140-b95230a9dbad // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-contrib/static v0.0.1 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.11.1 // indirect
+	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/gin-contrib/static v0.0.1/go.mod h1:CSxeF+wep05e0kCOsqWdAWbSszmc31zTI
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.8.2 h1:UzKToD9/PoFj/V4rvlKqTRKnQYyz8Sc1MJlv4JHPtvY=
 github.com/gin-gonic/gin v1.8.2/go.mod h1:qw5AYuDrzRTnhvusDsrov+fDIxp9Dleuu12h8nfB398=
+github.com/go-co-op/gocron v1.18.0 h1:SxTyJ5xnSN4byCq7b10LmmszFdxQlSQJod8s3gbnXxA=
+github.com/go-co-op/gocron v1.18.0/go.mod h1:sD/a0Aadtw5CpflUJ/lpP9Vfdk979Wl1Sg33HPHg0FY=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
@@ -71,6 +73,8 @@ github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
@@ -96,6 +100,8 @@ golang.org/x/crypto v0.4.0/go.mod h1:3quD/ATkf6oY+rnes5c3ExXTbLc8mueNue5/DoinL80
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
 golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,14 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/dlclark/regexp2 v1.7.0 h1:7lJfhqlPssTb1WQx4yvTHN0uElPEv52sbaECrAQxjAo=
+github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dop251/goja v0.0.0-20211022113120-dc8c55024d06/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
+github.com/dop251/goja v0.0.0-20221229151140-b95230a9dbad h1:EikyYzLzjRNW8lz9VAIUcmrwDAU6PsMRnwblYXb6Ysg=
+github.com/dop251/goja v0.0.0-20221229151140-b95230a9dbad/go.mod h1:yRkwfj0CBpOGre+TwBsqPV0IH0Pk73e4PXJOeNDboGs=
+github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
+github.com/dop251/goja_nodejs v0.0.0-20211022123610-8dd9abb0616d/go.mod h1:DngW8aVqWbuLRMHItjPUyqdj+HWPvnQe8V8y1nDpIbM=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-contrib/static v0.0.1 h1:JVxuvHPuUfkoul12N7dtQw7KRn/pSMq7Ue1Va9Swm1U=
@@ -22,6 +30,8 @@ github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.11.1 h1:prmOlTVv+YjZjmRmNSF3VmspqJIxJWXmqUsHwfTRRkQ=
 github.com/go-playground/validator/v10 v10.11.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
 github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -46,6 +56,8 @@ github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ic
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/jsapi/console.go
+++ b/jsapi/console.go
@@ -25,8 +25,14 @@ func (c *Console) Create() {
 }
 
 func (c *Console) Log(call js.FunctionCall) js.Value {
-	for _, arg := range call.Arguments {
-		fmt.Print(arg.String())
+	argc := len(call.Arguments)
+
+	for i, arg := range call.Arguments {
+		fmt.Print(arg)
+
+		if i != argc-1 {
+			fmt.Print(" ")
+		}
 	}
 
 	fmt.Println()

--- a/jsapi/console.go
+++ b/jsapi/console.go
@@ -25,14 +25,8 @@ func (c *Console) Create() {
 }
 
 func (c *Console) Log(call js.FunctionCall) js.Value {
-	argc := len(call.Arguments)
-
-	for i, arg := range call.Arguments {
-		fmt.Print(arg)
-
-		if i != argc-1 {
-			fmt.Print(" ")
-		}
+	for _, arg := range call.Arguments {
+		fmt.Print(arg, " ")
 	}
 
 	fmt.Println()

--- a/jsapi/console.go
+++ b/jsapi/console.go
@@ -1,0 +1,35 @@
+package jsapi
+
+import (
+	"fmt"
+
+	js "github.com/dop251/goja"
+)
+
+type consoleObj struct {
+	Log   func(call js.FunctionCall) js.Value `json:"log"`
+	Error func(call js.FunctionCall) js.Value `json:"error"`
+}
+
+type Console struct {
+	VM *js.Runtime
+}
+
+func (c *Console) Create() {
+	console := consoleObj{
+		Log:   c.Log,
+		Error: c.Log,
+	}
+
+	c.VM.Set("console", console)
+}
+
+func (c *Console) Log(call js.FunctionCall) js.Value {
+	for _, arg := range call.Arguments {
+		fmt.Print(arg.String())
+	}
+
+	fmt.Println()
+
+	return js.Undefined()
+}

--- a/jsapi/fetch.go
+++ b/jsapi/fetch.go
@@ -1,0 +1,82 @@
+package jsapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	js "github.com/dop251/goja"
+)
+
+type FetchOptions struct {
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers"`
+	Body    any               `json:"body"`
+}
+
+type FetchResponse struct {
+	JSON func(call js.FunctionCall) js.Value `json:"json"`
+	Text func(call js.FunctionCall) js.Value `json:"text"`
+}
+
+type Fetch struct {
+	VM *js.Runtime
+}
+
+func (f *Fetch) Create() {
+	f.VM.Set("fetch", f.fetchFn)
+}
+
+func (f *Fetch) fetchFn(call js.FunctionCall) js.Value {
+	if len(call.Arguments) < 2 {
+		return js.Undefined()
+	}
+
+	var options FetchOptions
+	url := call.Argument(0).ToString().String()
+	f.VM.ExportTo(call.Argument(1), &options)
+
+	promise, resolve, reject := f.VM.NewPromise()
+	fmt.Println(options.Method)
+
+	go func() {
+		if options.Method == "GET" {
+			resp, err := http.Get(url)
+
+			if err != nil {
+				reject(err.Error())
+				return
+			}
+
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+
+			fetchResponse := FetchResponse{
+				JSON: func(call js.FunctionCall) js.Value {
+					promise, resolve, reject := f.VM.NewPromise()
+
+					var obj interface{}
+					err := json.Unmarshal(body, &obj)
+
+					if err != nil {
+						reject(err.Error())
+					} else {
+						resolve(obj)
+					}
+
+					return f.VM.ToValue(promise)
+				},
+				Text: func(call js.FunctionCall) js.Value {
+					promise, resolve, _ := f.VM.NewPromise()
+					resolve(string(body))
+					return f.VM.ToValue(promise)
+				},
+			}
+
+			resolve(fetchResponse)
+		}
+	}()
+
+	return f.VM.ToValue(promise)
+}

--- a/jsapi/fetch.go
+++ b/jsapi/fetch.go
@@ -2,7 +2,6 @@ package jsapi
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -38,7 +37,6 @@ func (f *Fetch) fetchFn(call js.FunctionCall) js.Value {
 	f.VM.ExportTo(call.Argument(1), &options)
 
 	promise, resolve, reject := f.VM.NewPromise()
-	fmt.Println(options.Method)
 
 	go func() {
 		var resp *http.Response

--- a/jsapi/ip.go
+++ b/jsapi/ip.go
@@ -10,22 +10,22 @@ import (
 )
 
 type IPObj struct {
-	ParseList func(call js.FunctionCall) js.Value `json:"parseList"`
+	Parse func(call js.FunctionCall) js.Value `json:"parse"`
 }
 
-type JSIP struct {
+type IPList struct {
 	VM *js.Runtime
 }
 
-func (ip *JSIP) Init() {
+func (ip *IPList) Init() {
 	ipObj := IPObj{
-		ParseList: ip.ParseList,
+		Parse: ip.Parse,
 	}
 
-	ip.VM.Set("IP", ipObj)
+	ip.VM.Set("IPList", ipObj)
 }
 
-func (ip *JSIP) ParseList(call js.FunctionCall) js.Value {
+func (ip *IPList) Parse(call js.FunctionCall) js.Value {
 	if len(call.Arguments) < 1 {
 		return js.Undefined()
 	}

--- a/jsapi/ip.go
+++ b/jsapi/ip.go
@@ -39,6 +39,18 @@ func (ip *JSIP) constructor(call js.ConstructorCall) *js.Object {
 
 	inst.Set("ip", ipAddress)
 	inst.Set("isValid", obj.IP != nil)
+	inst.Set("isLoopback", func(_ js.FunctionCall) js.Value {
+		return ip.VM.ToValue(obj.IP.IsLoopback())
+	})
+	inst.Set("isPrivate", func(_ js.FunctionCall) js.Value {
+		return ip.VM.ToValue(obj.IP.IsPrivate())
+	})
+	inst.Set("isUnspecified", func(_ js.FunctionCall) js.Value {
+		return ip.VM.ToValue(obj.IP.IsUnspecified())
+	})
+	inst.Set("getMask", func(_ js.FunctionCall) js.Value {
+		return ip.VM.ToValue(obj.IP.DefaultMask().String())
+	})
 
 	// inst.Set("inc", func(call js.FunctionCall) js.Value {
 	// 	obj.Val += 1

--- a/jsapi/ip.go
+++ b/jsapi/ip.go
@@ -1,0 +1,50 @@
+package jsapi
+
+import (
+	"fmt"
+	"net"
+
+	js "github.com/dop251/goja"
+)
+
+type ipObj struct {
+	IP net.IP
+}
+
+type JSIP struct {
+	VM    *js.Runtime
+	Proto *js.Object
+}
+
+func (ip *JSIP) Init() {
+	cVal := ip.VM.ToValue(ip.constructor)
+	ip.Proto = cVal.(*js.Object).Get("prototype").(*js.Object)
+
+	ip.VM.Set("IP", cVal)
+}
+
+func (ip *JSIP) constructor(call js.ConstructorCall) *js.Object {
+	if len(call.Arguments) == 0 {
+		ip.VM.Interrupt(fmt.Errorf("an IP address is required"))
+		return nil
+	}
+
+	ipAddress := call.Argument(0)
+	inst := ip.VM.CreateObject(ip.Proto)
+	fmt.Println(ipAddress)
+
+	obj := ipObj{
+		IP: net.ParseIP(ipAddress.String()),
+	}
+
+	inst.Set("ip", ipAddress)
+	inst.Set("isValid", obj.IP != nil)
+
+	// inst.Set("inc", func(call js.FunctionCall) js.Value {
+	// 	obj.Val += 1
+	// 	inst.Set("val", obj.Val)
+	// 	return js.Undefined()
+	// })
+
+	return inst
+}

--- a/jsapi/ip.go
+++ b/jsapi/ip.go
@@ -1,0 +1,71 @@
+package jsapi
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+
+	js "github.com/dop251/goja"
+)
+
+type IPObj struct {
+	ParseList func(call js.FunctionCall) js.Value `json:"parseList"`
+}
+
+type JSIP struct {
+	VM *js.Runtime
+}
+
+func (ip *JSIP) Init() {
+	ipObj := IPObj{
+		ParseList: ip.ParseList,
+	}
+
+	ip.VM.Set("IP", ipObj)
+}
+
+func (ip *JSIP) ParseList(call js.FunctionCall) js.Value {
+	if len(call.Arguments) < 1 {
+		return js.Undefined()
+	}
+
+	promise, resolve, reject := ip.VM.NewPromise()
+	strList := call.Argument(0).ToString().String()
+
+	// Parses the list into a string array so that the JS engine will be able to interpret that.
+	list, err := parseSimpleIPList(strList)
+
+	if err != nil {
+		reject(err.Error())
+	} else {
+		resolve(list)
+	}
+
+	return ip.VM.ToValue(promise)
+}
+
+func parseSimpleIPList(list string) ([]string, error) {
+	lines := strings.Split(list, "\n")
+	ipAddresses := []string{}
+
+	for _, line := range lines {
+		re := regexp.MustCompile(`(#(?:[^\n]+)?)`)
+		line = strings.Trim(re.ReplaceAllLiteralString(line, ""), " ")
+
+		if len(line) == 0 {
+			continue
+		}
+
+		re = regexp.MustCompile(`(/\d+)`)
+		ip := net.ParseIP(re.ReplaceAllLiteralString(line, ""))
+
+		if ip == nil {
+			return nil, fmt.Errorf("invalid IP address %q", line)
+		}
+
+		ipAddresses = append(ipAddresses, line)
+	}
+
+	return ipAddresses, nil
+}

--- a/jsapi/ip.go
+++ b/jsapi/ip.go
@@ -71,14 +71,18 @@ func (ip *JSIP) constructor(call js.ConstructorCall) *js.Object {
 		return ip.VM.ToValue(obj.IP.DefaultMask().String())
 	})
 	inst.Set("contains", func(call js.FunctionCall) js.Value {
-		if !isCidrRange || len(call.Arguments) < 1 {
+		if len(call.Arguments) < 1 {
 			return ip.VM.ToValue(false)
 		}
 
 		ipAddress := call.Argument(0).String()
-		netIP := net.ParseIP(ipAddress)
+		netIPAddress := net.ParseIP(ipAddress)
 
-		return ip.VM.ToValue(ipRange.Contains(netIP))
+		if !isCidrRange {
+			return ip.VM.ToValue(netIPAddress.Equal(netIP))
+		} else {
+			return ip.VM.ToValue(ipRange.Contains(netIPAddress))
+		}
 	})
 
 	// inst.Set("inc", func(call js.FunctionCall) js.Value {

--- a/jsapi/ip.go
+++ b/jsapi/ip.go
@@ -85,11 +85,5 @@ func (ip *JSIP) constructor(call js.ConstructorCall) *js.Object {
 		}
 	})
 
-	// inst.Set("inc", func(call js.FunctionCall) js.Value {
-	// 	obj.Val += 1
-	// 	inst.Set("val", obj.Val)
-	// 	return js.Undefined()
-	// })
-
 	return inst
 }

--- a/jsapi/ip_list.go
+++ b/jsapi/ip_list.go
@@ -9,7 +9,7 @@ import (
 	js "github.com/dop251/goja"
 )
 
-type IPObj struct {
+type ipListObj struct {
 	Parse func(call js.FunctionCall) js.Value `json:"parse"`
 }
 
@@ -18,11 +18,11 @@ type IPList struct {
 }
 
 func (ip *IPList) Init() {
-	ipObj := IPObj{
+	obj := ipListObj{
 		Parse: ip.Parse,
 	}
 
-	ip.VM.Set("IPList", ipObj)
+	ip.VM.Set("IPList", obj)
 }
 
 func (ip *IPList) Parse(call js.FunctionCall) js.Value {

--- a/jsapi/ip_list.go
+++ b/jsapi/ip_list.go
@@ -31,7 +31,7 @@ func (ip *IPList) Parse(call js.FunctionCall) js.Value {
 	}
 
 	promise, resolve, reject := ip.VM.NewPromise()
-	strList := call.Argument(0).ToString().String()
+	strList := call.Argument(0).String()
 
 	// Parses the list into a string array so that the JS engine will be able to interpret that.
 	list, err := parseSimpleIPList(strList)

--- a/jsapi/storage.go
+++ b/jsapi/storage.go
@@ -1,0 +1,91 @@
+package jsapi
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	js "github.com/dop251/goja"
+)
+
+type Storage struct {
+	VM      *js.Runtime
+	DataDir string
+}
+
+func (s *Storage) Init() {
+	obj := s.VM.NewObject()
+	obj.Set("new", s.initStorage)
+	obj.Set("save", s.saveFile)
+	obj.Set("delete", s.deleteFile)
+
+	s.VM.Set("Storage", obj)
+}
+
+func (s *Storage) initStorage(_ js.FunctionCall) js.Value {
+	promise, resolve, reject := s.VM.NewPromise()
+	_, err := os.Stat(s.DataDir)
+
+	if err != nil && os.IsNotExist(err) {
+		err = os.Mkdir(s.DataDir, 0700)
+
+		if err != nil {
+			reject(err.Error())
+			return s.VM.ToValue(promise)
+		}
+	} else if err != nil {
+		reject(err.Error())
+		return s.VM.ToValue(promise)
+	}
+
+	resolve(js.Undefined())
+
+	return s.VM.ToValue(promise)
+}
+
+func (s *Storage) saveFile(call js.FunctionCall) js.Value {
+	promise, resolve, reject := s.VM.NewPromise()
+
+	if len(call.Arguments) < 2 {
+		err := fmt.Errorf("\"save\" requires 2 arguments, received %d", len(call.Arguments))
+		reject(err.Error())
+		return s.VM.ToValue(promise)
+	}
+
+	fileName := call.Argument(0).String()
+	contents := call.Argument(1).String()
+
+	file, err := os.Create(filepath.Join(s.DataDir, fileName))
+
+	if err != nil {
+		reject(err.Error())
+		return s.VM.ToValue(promise)
+	}
+
+	_, err = file.Write([]byte(contents))
+
+	if err != nil {
+		reject(err.Error())
+	} else {
+		resolve(js.Undefined())
+	}
+
+	return s.VM.ToValue(promise)
+}
+
+func (s *Storage) deleteFile(call js.FunctionCall) js.Value {
+	if len(call.Arguments) < 1 {
+		return js.Undefined()
+	}
+
+	promise, resolve, reject := s.VM.NewPromise()
+	fileName := call.Argument(0).String()
+
+	if err := os.Remove(filepath.Join(s.DataDir, fileName)); err != nil {
+		reject(err.Error())
+	} else {
+		resolve(js.Undefined())
+	}
+
+	return s.VM.ToValue(promise)
+}

--- a/jsapi/storage.go
+++ b/jsapi/storage.go
@@ -99,7 +99,7 @@ func (s *Storage) readFile(call js.FunctionCall) js.Value {
 	promise, resolve, reject := s.VM.NewPromise()
 	fileName := call.Argument(0).String()
 
-	contents, err := os.ReadFile(fileName)
+	contents, err := os.ReadFile(filepath.Join(s.DataDir, fileName))
 
 	if err != nil {
 		reject(err.Error())

--- a/jsapi/storage.go
+++ b/jsapi/storage.go
@@ -15,11 +15,11 @@ type Storage struct {
 
 func (s *Storage) Init() {
 	obj := s.VM.NewObject()
-	obj.Set("new", s.initStorage)
+	obj.Set("init", s.initStorage)
 	obj.Set("save", s.saveFile)
 	obj.Set("delete", s.deleteFile)
 
-	s.VM.Set("Storage", obj)
+	s.VM.Set("storage", obj)
 }
 
 func (s *Storage) initStorage(_ js.FunctionCall) js.Value {

--- a/jsapi/storage.go
+++ b/jsapi/storage.go
@@ -18,6 +18,7 @@ func (s *Storage) Init() {
 	obj.Set("init", s.initStorage)
 	obj.Set("save", s.saveFile)
 	obj.Set("delete", s.deleteFile)
+	obj.Set("read", s.readFile)
 
 	s.VM.Set("storage", obj)
 }
@@ -85,6 +86,25 @@ func (s *Storage) deleteFile(call js.FunctionCall) js.Value {
 		reject(err.Error())
 	} else {
 		resolve(js.Undefined())
+	}
+
+	return s.VM.ToValue(promise)
+}
+
+func (s *Storage) readFile(call js.FunctionCall) js.Value {
+	if len(call.Arguments) < 1 {
+		return js.Undefined()
+	}
+
+	promise, resolve, reject := s.VM.NewPromise()
+	fileName := call.Argument(0).String()
+
+	contents, err := os.ReadFile(fileName)
+
+	if err != nil {
+		reject(err.Error())
+	} else {
+		resolve(string(contents))
 	}
 
 	return s.VM.ToValue(promise)

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var whiteListedIPRanges []*net.IPNet
 var whiteListedIPs []net.IP
 var hasWhitelist = false
 var dnsServerList = []string{}
+var extensions []*Extension
 
 func middleware(c *gin.Context) {
 	// If there was no whitelist specified, then we can proceed.
@@ -56,13 +57,14 @@ func middleware(c *gin.Context) {
 
 // https://github.com/allegro/bigcache
 
-func GetDomainInformation(hostname string) ([]*IPRecord, error) {
+func GetDomainInformation(hostname string) ([]*IPRecord, []any, error) {
 	var records []*IPRecord = []*IPRecord{}
+	var additionalData []any = []any{}
 
 	// Is this a valid domain name?
 	if !govalidator.IsDNSName(hostname) {
 		// Make sure the request is valid.
-		return records, errors.New("invalid input")
+		return records, additionalData, errors.New("invalid input")
 	}
 
 	// Perform a DNS lookup.
@@ -70,7 +72,7 @@ func GetDomainInformation(hostname string) ([]*IPRecord, error) {
 
 	for i := 0; i < len(ips); i++ {
 		// Get the information on the current IP.
-		info, err := GetIPInformation(ips[i].String())
+		info, addlData, err := GetIPInformation(ips[i].String())
 
 		if err != nil {
 			continue
@@ -78,12 +80,13 @@ func GetDomainInformation(hostname string) ([]*IPRecord, error) {
 
 		// Append the record to the array.
 		records = append(records, info)
+		additionalData = append(additionalData, addlData...)
 	}
 
-	return records, nil
+	return records, additionalData, nil
 }
 
-func GetIPInformation(hostname string) (*IPRecord, error) {
+func GetIPInformation(hostname string) (*IPRecord, []any, error) {
 	// If you are using strings that may be invalid, check that ip is not nil.
 	ip := net.ParseIP(hostname)
 
@@ -95,7 +98,7 @@ func GetIPInformation(hostname string) (*IPRecord, error) {
 
 	if err != nil {
 		log.Println(err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Lookup the IP details from the ASN database.
@@ -103,18 +106,34 @@ func GetIPInformation(hostname string) (*IPRecord, error) {
 
 	if err != nil {
 		log.Println(err)
-		return nil, err
+		return nil, nil, err
+	}
+
+	var addlData []any
+
+	for _, ext := range extensions {
+		if !ext.IsLookupExtension() {
+			continue
+		}
+
+		// Here we query the extension for information on the queried IP address. This data will
+		// be added on to the response payload in the end as additional information.
+		data, _ := ext.RunIPLookup(ip.String())
+
+		if data != nil {
+			addlData = append(addlData, data)
+		}
 	}
 
 	rec.IPAddress = hostname
 
-	return rec, nil
+	return rec, addlData, nil
 }
 
 func IPAddressHandler(c *gin.Context) {
 	hostname := c.Param("hostname")
-	response := &IPApiResponse{}
-	response.Record = nil
+	response := &ApiResponse{}
+	response.Data = nil
 
 	// Is this a valid IP address?
 	if !IsValidIP(hostname) {
@@ -130,7 +149,7 @@ func IPAddressHandler(c *gin.Context) {
 	response.Status = "Retrieved"
 
 	// Get the IP information for this.
-	response.Record, err = GetIPInformation(hostname)
+	response.Data, response.AddlData, err = GetIPInformation(hostname)
 
 	if err != nil {
 		response.Status = err.Error()
@@ -141,8 +160,8 @@ func IPAddressHandler(c *gin.Context) {
 
 func DomainHandler(c *gin.Context) {
 	hostname := c.Param("hostname")
-	response := &MultiApiResponse{}
-	response.Records, err = GetDomainInformation(hostname)
+	response := &ApiResponse{}
+	response.Data, response.AddlData, err = GetDomainInformation(hostname)
 
 	if err == nil {
 		response.Success = true
@@ -201,8 +220,6 @@ func main() {
 
 	defer cityMmdb.Close()
 	defer asnMmdb.Close()
-
-	var extensions []*Extension
 
 	if len(*extFolder) > 0 {
 		extensions, err = parseExtensions(*extFolder)
@@ -293,12 +310,12 @@ func main() {
 		http.ListenAndServe(fmt.Sprintf("%s:8228", *serveIP), r)
 	} else if *domainPtr != "" {
 		// Grab the domain information.
-		recs, _ := GetDomainInformation(*domainPtr)
+		recs, _, _ := GetDomainInformation(*domainPtr)
 		obj, _ := json.Marshal(recs)
 		fmt.Println(string(obj))
 	} else if *ipPtr != "" {
 		// Grab the information about the sole IP address.
-		rec, _ := GetIPInformation(*ipPtr)
+		rec, _, _ := GetIPInformation(*ipPtr)
 		obj, _ := json.Marshal(rec)
 		fmt.Println(string(obj))
 	} else {

--- a/types.go
+++ b/types.go
@@ -21,6 +21,12 @@ type IPRecord struct {
 }
 
 type ApiResponse struct {
+	Success bool   `json:"success"`
+	Status  string `json:"status"`
+	Data    any    `json:"data"`
+}
+
+type IPApiResponse struct {
 	Success bool      `json:"success"`
 	Status  string    `json:"status"`
 	Record  *IPRecord `json:"record"`

--- a/types.go
+++ b/types.go
@@ -21,9 +21,10 @@ type IPRecord struct {
 }
 
 type ApiResponse struct {
-	Success bool   `json:"success"`
-	Status  string `json:"status"`
-	Data    any    `json:"data"`
+	Success  bool   `json:"success"`
+	Status   string `json:"status"`
+	Data     any    `json:"data"`
+	AddlData []any  `json:"additional_data"`
 }
 
 type IPApiResponse struct {

--- a/utils.go
+++ b/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -94,4 +95,51 @@ func fileExists(path string) bool {
 	}
 
 	return true
+}
+
+func parseExtensions(path string) ([]*Extension, error) {
+	files, err := os.ReadDir(path)
+	extensions := []*Extension{}
+
+	if err != nil {
+		return extensions, err
+	}
+
+	for _, f := range files {
+		if !f.IsDir() {
+			break
+		}
+
+		extFiles, err := os.ReadDir(filepath.Join(path, f.Name()))
+
+		if err != nil {
+			return extensions, err
+		}
+
+		var entry os.DirEntry = nil
+
+		for _, extFile := range extFiles {
+			if extFile.IsDir() {
+				continue
+			}
+
+			if extFile.Name() == "index.js" {
+				entry = extFile
+			}
+		}
+
+		if entry == nil {
+			return extensions, fmt.Errorf("Extension folder %q doesn't have an entry point (index.js)", f.Name())
+		}
+
+		extension := &Extension{
+			extDir: path,
+			dir:    f,
+			entry:  entry,
+		}
+
+		extensions = append(extensions, extension)
+	}
+
+	return extensions, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -32,7 +32,7 @@ func ParseIPList(file *os.File) ([]*net.IPNet, []net.IP, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		re := regexp.MustCompile(`(#[\s\S]+)`)
+		re := regexp.MustCompile(`(#(?:[^\n]+)?)`)
 		line = strings.Trim(re.ReplaceAllLiteralString(line, ""), " ")
 
 		if len(line) == 0 {
@@ -70,7 +70,7 @@ func ParseDNSServerList(file *os.File) ([]string, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		re := regexp.MustCompile(`(#[\s\S]+)`)
+		re := regexp.MustCompile(`(#(?:[^\n]+)?)`)
 		line = strings.Trim(re.ReplaceAllLiteralString(line, ""), " ")
 
 		if len(line) == 0 {


### PR DESCRIPTION
This PR adds the ability to create and run extensions (aka plugins) that massage and query their own data sources. It was meant to allow the addition of capabilities that I didn't want to be in the main code of the app.

Extensions are based on the [goja](https://github.com/dop251/goja) Javascript engine and run in a sandboxed environment. Extensions can register endpoints, save and retrieve files from their own personal storage directory (which is the `.store` folder in the extension folder). 

Only `GET` is implemented for use with `fetch` for now, although this will change. In fact, a lot is missing because this PR became too large. I will be making additions and fixes gradually.